### PR TITLE
query too slow

### DIFF
--- a/pkg/deviced/service/add_configs_to_device.go
+++ b/pkg/deviced/service/add_configs_to_device.go
@@ -20,7 +20,7 @@ func (self *MetathingsDevicedService) AddConfigsToDevice(ctx context.Context, re
 
 	dev := req.GetDevice()
 	dev_id_str := dev.GetId().GetValue()
-	logger := self.logger.WithField("device", dev_id_str)
+	logger := self.get_logger().WithField("device", dev_id_str)
 
 	var cfg_ids_str []string
 	for _, cfg := range req.GetConfigs() {

--- a/pkg/deviced/service/add_devices_to_firmware_hub.go
+++ b/pkg/deviced/service/add_devices_to_firmware_hub.go
@@ -34,7 +34,7 @@ func (self *MetathingsDevicedService) AddDevicesToFirmwareHub(ctx context.Contex
 
 	fh := req.GetFirmwareHub()
 	fh_id_str := fh.GetId().GetValue()
-	logger := self.logger.WithField("firmware_hub", fh_id_str)
+	logger := self.get_logger().WithField("firmware_hub", fh_id_str)
 
 	var dev_ids_str []string
 	for _, dev := range req.GetDevices() {

--- a/pkg/deviced/service/add_firmware_descriptor_to_firmware_hub.go
+++ b/pkg/deviced/service/add_firmware_descriptor_to_firmware_hub.go
@@ -70,7 +70,7 @@ func (self *MetathingsDevicedService) AddFirmwareDescriptorToFirmwareHub(ctx con
 	desc_id_str := id_helper.NewId()
 	desc_name_str := desc.GetName().GetValue()
 
-	logger := self.logger.WithFields(log.Fields{
+	logger := self.get_logger().WithFields(log.Fields{
 		"firmware_hub":        fh_id_str,
 		"firmware_descriptor": desc_name_str,
 	})

--- a/pkg/deviced/service/add_flows_to_flow_set.go
+++ b/pkg/deviced/service/add_flows_to_flow_set.go
@@ -18,19 +18,26 @@ func (self *MetathingsDevicedService) AuthorizeAddFlowsToFlowSet(ctx context.Con
 func (self *MetathingsDevicedService) AddFlowsToFlowSet(ctx context.Context, req *pb.AddFlowsToFlowSetRequest) (*empty.Empty, error) {
 	var err error
 
+	logger := self.get_logger()
+
 	flwst := req.GetFlowSet()
 	flwst_id := flwst.GetId().GetValue()
 
 	devs := req.GetDevices()
 	flw_ids, err := self.get_flow_ids_by_devices(ctx, devs)
 	if err != nil {
-		self.logger.WithError(err).Errorf("failed to get flow ids by devices")
+		logger.WithError(err).Errorf("failed to get flow ids by devices")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
+	logger = logger.WithFields(log.Fields{
+		"flow_set": flwst_id,
+		"flows":    flw_ids,
+	})
+
 	flwst_s, err := self.storage.GetFlowSet(ctx, flwst_id)
 	if err != nil {
-		self.logger.WithError(err).Errorf("failed to get flow set in storage")
+		logger.WithError(err).Errorf("failed to get flow set in storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -51,17 +58,13 @@ func (self *MetathingsDevicedService) AddFlowsToFlowSet(ctx context.Context, req
 
 	for _, flw_id := range flw_ids_expect {
 		if err = self.storage.AddFlowToFlowSet(ctx, flwst_id, flw_id); err != nil {
-			self.logger.WithError(err).Errorf("failed to add flow to flow set")
+			logger.WithError(err).Errorf("failed to add flow to flow set")
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
 	}
 
 	// TODO(Peer): dynamic add flow to pushing flow.
-
-	self.logger.WithFields(log.Fields{
-		"flow_set": flwst_id,
-		"flows":    flw_ids_expect,
-	}).Infof("add flows to flow set")
+	logger.Infof("add flows to flow set")
 
 	return &empty.Empty{}, nil
 }

--- a/pkg/deviced/service/create_config.go
+++ b/pkg/deviced/service/create_config.go
@@ -53,9 +53,11 @@ func (self *MetathingsDevicedService) CreateConfig(ctx context.Context, req *pb.
 	cfg_alias_str := cfg.GetAlias().GetValue()
 	cfg_body := cfg.GetBody()
 
+	logger := self.get_logger().WithField("config", cfg_id_str)
+
 	cfg_body_str, err := new(jsonpb.Marshaler).MarshalToString(cfg_body)
 	if err != nil {
-		self.logger.WithError(err).Errorf("failed to marshal config body to string")
+		logger.WithError(err).Errorf("failed to marshal config body to string")
 		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
 
@@ -66,7 +68,7 @@ func (self *MetathingsDevicedService) CreateConfig(ctx context.Context, req *pb.
 	}
 
 	if cfg_s, err = self.storage.CreateConfig(ctx, cfg_s); err != nil {
-		self.logger.WithError(err).Errorf("failed to create config in storage")
+		logger.WithError(err).Errorf("failed to create config in storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -74,7 +76,7 @@ func (self *MetathingsDevicedService) CreateConfig(ctx context.Context, req *pb.
 		Config: copy_config(cfg_s),
 	}
 
-	self.logger.WithField("id", cfg_id_str).Infof("create config")
+	logger.Infof("create config")
 
 	return res, nil
 }

--- a/pkg/deviced/service/create_device.go
+++ b/pkg/deviced/service/create_device.go
@@ -116,6 +116,8 @@ func (self *MetathingsDevicedService) CreateDevice(ctx context.Context, req *pb.
 		dev_alias_str = dev.GetAlias().GetValue()
 	}
 
+	logger := self.get_logger().WithField("device", dev_id_str)
+
 	dev_s := &storage.Device{
 		Id:    &dev_id_str,
 		Kind:  &dev_kind_str,
@@ -129,7 +131,7 @@ func (self *MetathingsDevicedService) CreateDevice(ctx context.Context, req *pb.
 	}
 
 	if err = self.create_device_entity(ctx, dev_s); err != nil {
-		self.logger.WithError(err).Errorf("failed to create entity for device")
+		logger.WithError(err).Errorf("failed to create entity for device")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -155,12 +157,12 @@ func (self *MetathingsDevicedService) CreateDevice(ctx context.Context, req *pb.
 		}
 
 		if err = self.create_module_entity(ctx, mdl_s); err != nil {
-			self.logger.WithError(err).Errorf("failed to create entity for module")
+			logger.WithError(err).Errorf("failed to create entity for module")
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
 
 		if _, err = self.storage.CreateModule(ctx, mdl_s); err != nil {
-			self.logger.WithError(err).Errorf("failed to create module in storage")
+			logger.WithError(err).Errorf("failed to create module in storage")
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
 	}
@@ -182,18 +184,18 @@ func (self *MetathingsDevicedService) CreateDevice(ctx context.Context, req *pb.
 		}
 
 		if err = self.create_flow_entity(ctx, flw_s); err != nil {
-			self.logger.WithError(err).Errorf("failed to create entity to flow")
+			logger.WithError(err).Errorf("failed to create entity to flow")
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
 
 		if _, err = self.storage.CreateFlow(ctx, flw_s); err != nil {
-			self.logger.WithError(err).Errorf("failed to create flow in storage")
+			logger.WithError(err).Errorf("failed to create flow in storage")
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
 	}
 
 	if dev_s, err = self.storage.CreateDevice(ctx, dev_s); err != nil {
-		self.logger.WithError(err).Errorf("failed to create device in storage")
+		logger.WithError(err).Errorf("failed to create device in storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -201,7 +203,7 @@ func (self *MetathingsDevicedService) CreateDevice(ctx context.Context, req *pb.
 		Device: copy_device(dev_s),
 	}
 
-	self.logger.WithField("id", dev_id_str).Infof("create device")
+	logger.Infof("create device")
 
 	return res, nil
 }

--- a/pkg/deviced/service/create_firmware_hub.go
+++ b/pkg/deviced/service/create_firmware_hub.go
@@ -37,7 +37,7 @@ func (self *MetathingsDevicedService) CreateFirmwareHub(ctx context.Context, req
 		fh_id_str = fh.GetId().GetValue()
 	}
 
-	logger := self.logger.WithFields(log.Fields{
+	logger := self.get_logger().WithFields(log.Fields{
 		"id": fh_id_str,
 	})
 

--- a/pkg/deviced/service/create_flow_set.go
+++ b/pkg/deviced/service/create_flow_set.go
@@ -51,6 +51,8 @@ func (self *MetathingsDevicedService) CreateFlowSet(ctx context.Context, req *pb
 		flwst_alias_str = flwst.GetAlias().GetValue()
 	}
 
+	logger := self.get_logger().WithField("flow_set", flwst_id_str)
+
 	flwst_s := &storage.FlowSet{
 		Id:    &flwst_id_str,
 		Name:  &flwst_name_str,
@@ -58,7 +60,7 @@ func (self *MetathingsDevicedService) CreateFlowSet(ctx context.Context, req *pb
 	}
 
 	if flwst_s, err = self.storage.CreateFlowSet(ctx, flwst_s); err != nil {
-		self.logger.WithError(err).Errorf("failed to create flow set in storage")
+		logger.WithError(err).Errorf("failed to create flow set in storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -66,7 +68,7 @@ func (self *MetathingsDevicedService) CreateFlowSet(ctx context.Context, req *pb
 		FlowSet: copy_flow_set(flwst_s),
 	}
 
-	self.logger.WithField("id", flwst_id_str).Infof("create flow set")
+	logger.Infof("create flow set")
 
 	return res, nil
 }

--- a/pkg/deviced/service/delete_config.go
+++ b/pkg/deviced/service/delete_config.go
@@ -33,7 +33,7 @@ func (self *MetathingsDevicedService) DeleteConfig(ctx context.Context, req *pb.
 
 	cfg_id_str := req.GetConfig().GetId().GetValue()
 
-	logger := self.logger.WithField("config", cfg_id_str)
+	logger := self.get_logger().WithField("config", cfg_id_str)
 
 	if err = self.storage.RemoveConfigFromDeviceByConfigId(ctx, cfg_id_str); err != nil {
 		logger.WithError(err).Errorf("failed to remove config form device by config id in storage")

--- a/pkg/deviced/service/delete_device.go
+++ b/pkg/deviced/service/delete_device.go
@@ -34,31 +34,33 @@ func (self *MetathingsDevicedService) DeleteDevice(ctx context.Context, req *pb.
 	var err error
 
 	dev_id_str := req.GetDevice().GetId().GetValue()
+	logger := self.get_logger().WithField("device", dev_id_str)
+
 	if dev, err = self.storage.GetDevice(ctx, dev_id_str); err != nil {
-		self.logger.WithError(err).Errorf("failed to get device in storage")
+		logger.WithError(err).Errorf("failed to get device in storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
 	for _, m := range dev.Modules {
 		mdl_id_str := *m.Id
 		if err = self.storage.DeleteModule(ctx, mdl_id_str); err != nil {
-			self.logger.WithError(err).WithField("id", mdl_id_str).Warningf("failed to delete module in storage")
+			logger.WithError(err).WithField("id", mdl_id_str).Warningf("failed to delete module in storage")
 		}
 	}
 
 	for _, f := range dev.Flows {
 		flw_id_str := *f.Id
 		if err = self.storage.DeleteFlow(ctx, flw_id_str); err != nil {
-			self.logger.WithError(err).WithField("id", flw_id_str).Warningf("failed to delete flow in storage")
+			logger.WithError(err).WithField("id", flw_id_str).Warningf("failed to delete flow in storage")
 		}
 	}
 
 	if err = self.storage.DeleteDevice(ctx, dev_id_str); err != nil {
-		self.logger.WithError(err).Debugf("failed to delete device in storage")
+		logger.WithError(err).Debugf("failed to delete device in storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
-	self.logger.WithField("id", dev_id_str).Infof("delete device")
+	logger.WithField("id", dev_id_str).Infof("delete device")
 
 	return &empty.Empty{}, nil
 }

--- a/pkg/deviced/service/delete_firmware_hub.go
+++ b/pkg/deviced/service/delete_firmware_hub.go
@@ -35,7 +35,7 @@ func (self *MetathingsDevicedService) DeleteFirmwareHub(ctx context.Context, req
 	var err error
 
 	fh_id_str := req.GetFirmwareHub().GetId().GetValue()
-	logger := self.logger.WithField("id", fh_id_str)
+	logger := self.get_logger().WithField("id", fh_id_str)
 
 	if fh, err = self.storage.GetFirmwareHub(ctx, fh_id_str); err != nil {
 		logger.WithError(err).Errorf("failed to get firmware hub in storage")

--- a/pkg/deviced/service/delete_flow_set.go
+++ b/pkg/deviced/service/delete_flow_set.go
@@ -34,24 +34,26 @@ func (self *MetathingsDevicedService) DeleteFlowSet(ctx context.Context, req *pb
 	var err error
 
 	flwst_id_str := req.GetFlowSet().GetId().GetValue()
+	logger := self.get_logger().WithField("flow_set", flwst_id_str)
+
 	if flwst, err = self.storage.GetFlowSet(ctx, flwst_id_str); err != nil {
-		self.logger.WithError(err).Errorf("failed to get flow set in storage")
+		logger.WithError(err).Errorf("failed to get flow set in storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
 	for _, flw := range flwst.Flows {
 		if err = self.storage.RemoveFlowFromFlowSet(ctx, flwst_id_str, *flw.Id); err != nil {
-			self.logger.WithError(err).Errorf("failed to remove flow from flow set")
+			logger.WithError(err).Errorf("failed to remove flow from flow set")
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
 	}
 
 	if err = self.storage.DeleteFlowSet(ctx, flwst_id_str); err != nil {
-		self.logger.WithError(err).Errorf("failed to delete flow set in storage")
+		logger.WithError(err).Errorf("failed to delete flow set in storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
-	self.logger.WithField("id", flwst_id_str).Infof("delete flow set")
+	logger.Infof("delete flow set")
 
 	return &empty.Empty{}, nil
 }

--- a/pkg/deviced/service/get_config.go
+++ b/pkg/deviced/service/get_config.go
@@ -36,7 +36,7 @@ func (self *MetathingsDevicedService) GetConfig(ctx context.Context, req *pb.Get
 	var err error
 
 	cfg_id_str := req.GetConfig().GetId().GetValue()
-	logger := self.logger.WithFields(log.Fields{
+	logger := self.get_logger().WithFields(log.Fields{
 		"config": cfg_id_str,
 	})
 

--- a/pkg/deviced/service/get_descriptor.go
+++ b/pkg/deviced/service/get_descriptor.go
@@ -29,14 +29,16 @@ func (self *MetathingsDevicedService) ValidateGetDescriptor(ctx context.Context,
 func (self *MetathingsDevicedService) GetDescriptor(ctx context.Context, req *pb.GetDescriptorRequest) (*pb.GetDescriptorResponse, error) {
 	sha1 := req.GetDescriptor_().GetSha1().GetValue()
 
+	logger := self.get_logger().WithField("sha1", sha1)
+
 	body, err := self.desc_storage.GetDescriptor(sha1)
 	if err != nil {
 		if err == descriptor_storage.ErrDescriptorNotFound {
-			self.logger.WithError(err).Errorf("descriptor sha1 not found")
+			logger.WithError(err).Errorf("descriptor sha1 not found")
 			return nil, status.Errorf(codes.NotFound, err.Error())
 		}
 
-		self.logger.WithError(err).Errorf("failed to get descriptor with sha1 in descriptor storage")
+		logger.WithError(err).Errorf("failed to get descriptor with sha1 in descriptor storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -47,7 +49,7 @@ func (self *MetathingsDevicedService) GetDescriptor(ctx context.Context, req *pb
 		},
 	}
 
-	self.logger.WithField("sha1", sha1).Debugf("get descriptor")
+	logger.Debugf("get descriptor")
 
 	return res, nil
 }

--- a/pkg/deviced/service/get_device.go
+++ b/pkg/deviced/service/get_device.go
@@ -33,8 +33,10 @@ func (self *MetathingsDevicedService) GetDevice(ctx context.Context, req *pb.Get
 	var err error
 
 	dev_id_str := req.GetDevice().GetId().GetValue()
+	logger := self.get_logger().WithField("device", dev_id_str)
+
 	if dev_s, err = self.storage.GetDevice(ctx, dev_id_str); err != nil {
-		self.logger.WithError(err).Errorf("failed to get device in storage")
+		logger.WithError(err).Errorf("failed to get device in storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -42,7 +44,7 @@ func (self *MetathingsDevicedService) GetDevice(ctx context.Context, req *pb.Get
 		Device: copy_device(dev_s),
 	}
 
-	self.logger.WithField("id", dev_id_str).Debugf("get device")
+	logger.Debugf("get device")
 
 	return res, nil
 }

--- a/pkg/deviced/service/get_device_by_module.go
+++ b/pkg/deviced/service/get_device_by_module.go
@@ -3,7 +3,6 @@ package metathings_deviced_service
 import (
 	"context"
 
-	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -34,8 +33,10 @@ func (self *MetathingsDevicedService) GetDeviceByModule(ctx context.Context, req
 	var err error
 
 	mdl_id_str := req.GetModule().GetId().GetValue()
+	logger := self.get_logger().WithField("module", mdl_id_str)
+
 	if dev_s, err = self.storage.GetDeviceByModuleId(ctx, mdl_id_str); err != nil {
-		self.logger.WithError(err).Errorf("failed to get device by module id in storage")
+		logger.WithError(err).Errorf("failed to get device by module id in storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -43,9 +44,7 @@ func (self *MetathingsDevicedService) GetDeviceByModule(ctx context.Context, req
 		Device: copy_device(dev_s),
 	}
 
-	self.logger.WithFields(log.Fields{
-		"module_id": mdl_id_str,
-	}).Debugf("get device by module")
+	logger.Debugf("get device by module")
 
 	return res, nil
 }

--- a/pkg/deviced/service/get_device_firmware_descriptor.go
+++ b/pkg/deviced/service/get_device_firmware_descriptor.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (self *MetathingsDevicedService) get_device_firmware_descriptor(ctx context.Context, dev_id_str string) (fd_s *storage.FirmwareDescriptor, error error) {
-	logger := self.logger.WithField("device", dev_id_str)
+	logger := self.get_logger().WithField("device", dev_id_str)
 
 	dev_s, err := self.storage.GetDevice(ctx, dev_id_str)
 	if err != nil {
@@ -124,7 +124,7 @@ func (self *MetathingsDevicedService) GetDeviceFirmwareDescriptor(ctx context.Co
 
 	dev := req.GetDevice()
 	dev_id_str := dev.GetId().GetValue()
-	logger := self.logger.WithField("device", dev_id_str)
+	logger := self.get_logger().WithField("device", dev_id_str)
 
 	fd_s, err := self.get_device_firmware_descriptor(ctx, dev_id_str)
 	if err != nil {

--- a/pkg/deviced/service/get_firmware_hub.go
+++ b/pkg/deviced/service/get_firmware_hub.go
@@ -30,7 +30,7 @@ func (self *MetathingsDevicedService) GetFirmwareHub(ctx context.Context, req *p
 	var err error
 
 	frm_hub_id_str := req.GetFirmwareHub().GetId().GetValue()
-	logger := self.logger.WithField("firmware_hub", frm_hub_id_str)
+	logger := self.get_logger().WithField("firmware_hub", frm_hub_id_str)
 
 	if frm_hub_s, err = self.storage.GetFirmwareHub(ctx, frm_hub_id_str); err != nil {
 		logger.WithError(err).Errorf("failed to get firmware hub in storage")

--- a/pkg/deviced/service/get_flow_set.go
+++ b/pkg/deviced/service/get_flow_set.go
@@ -33,8 +33,10 @@ func (self *MetathingsDevicedService) GetFlowSet(ctx context.Context, req *pb.Ge
 	var err error
 
 	flwst_id_str := req.GetFlowSet().GetId().GetValue()
+	logger := self.get_logger().WithField("flow_set", flwst_id_str)
+
 	if flwst_s, err = self.storage.GetFlowSet(ctx, flwst_id_str); err != nil {
-		self.logger.WithError(err).Errorf("failed to get flow set in storage")
+		logger.WithError(err).Errorf("failed to get flow set in storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -42,7 +44,7 @@ func (self *MetathingsDevicedService) GetFlowSet(ctx context.Context, req *pb.Ge
 		FlowSet: copy_flow_set(flwst_s),
 	}
 
-	self.logger.WithField("id", flwst_id_str).Debugf("get flow set")
+	logger.Debugf("get flow set")
 
 	return res, nil
 }

--- a/pkg/deviced/service/get_object.go
+++ b/pkg/deviced/service/get_object.go
@@ -36,26 +36,30 @@ func (self *MetathingsDevicedService) GetObject(ctx context.Context, req *pb.Get
 	obj := req.GetObject()
 	obj_s := parse_object(obj)
 
+	logger := self.get_logger()
+
 	obj_s, err := self.simple_storage.GetObject(obj_s)
 	if err != nil {
 		switch err {
 		case os.ErrNotExist:
-			self.logger.WithError(err).Warningf("object not found")
+			logger.WithError(err).Warningf("object not found")
 			return nil, status.Errorf(codes.NotFound, err.Error())
 		default:
-			self.logger.WithError(err).Errorf("failed to get object in simple storage")
+			logger.WithError(err).Errorf("failed to get object in simple storage")
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
 	}
+
+	logger = logger.WithFields(log.Fields{
+		"device": obj_s.Device,
+		"object": obj_s.FullName(),
+	})
 
 	res := &pb.GetObjectResponse{
 		Object: copy_object(obj_s),
 	}
 
-	self.logger.WithFields(log.Fields{
-		"device": obj_s.Device,
-		"object": obj_s.FullName(),
-	}).Debugf("get object")
+	logger.Debugf("get object")
 
 	return res, nil
 }

--- a/pkg/deviced/service/get_object_content.go
+++ b/pkg/deviced/service/get_object_content.go
@@ -34,13 +34,15 @@ func (self *MetathingsDevicedService) GetObjectContent(ctx context.Context, req 
 	obj := req.GetObject()
 	obj_s := parse_object(obj)
 
+	logger := self.get_logger()
+
 	ch, err := self.simple_storage.GetObjectContent(obj_s)
 	if err != nil {
 		switch err {
 		case os.ErrNotExist:
-			self.logger.WithError(err).Warningf("object not found")
+			logger.WithError(err).Warningf("object not found")
 		default:
-			self.logger.WithError(err).Errorf("failed to get object content in simple storage")
+			logger.WithError(err).Errorf("failed to get object content in simple storage")
 		}
 		return nil, self.ParseError(err)
 	}
@@ -54,12 +56,14 @@ func (self *MetathingsDevicedService) GetObjectContent(ctx context.Context, req 
 		contents = append(contents, buf...)
 	}
 
-	res := &pb.GetObjectContentResponse{Content: contents}
-
-	self.logger.WithFields(log.Fields{
+	logger = logger.WithFields(log.Fields{
 		"device": obj_s.Device,
 		"object": obj_s.FullName(),
-	}).Debugf("get object content")
+	})
+
+	res := &pb.GetObjectContentResponse{Content: contents}
+
+	logger.Debugf("get object content")
 
 	return res, nil
 }

--- a/pkg/deviced/service/list_configs.go
+++ b/pkg/deviced/service/list_configs.go
@@ -16,7 +16,7 @@ func (self *MetathingsDevicedService) ListConfigs(ctx context.Context, req *pb.L
 
 	cfg := req.GetConfig()
 	cfg_s := &storage.Config{}
-	logger := self.logger
+	logger := self.get_logger()
 
 	if cfg.GetId().GetValue() != "" {
 		cfg_s.Id = &cfg.Id.Value

--- a/pkg/deviced/service/list_configs_by_device.go
+++ b/pkg/deviced/service/list_configs_by_device.go
@@ -36,7 +36,7 @@ func (self *MetathingsDevicedService) ListConfigsByDevice(ctx context.Context, r
 
 	dev := req.GetDevice()
 	dev_id_str := dev.GetId().GetValue()
-	logger := self.logger.WithField("device", dev_id_str)
+	logger := self.get_logger().WithField("device", dev_id_str)
 
 	if cfgs_s, err = self.storage.ListConfigsByDeviceId(ctx, dev_id_str); err != nil {
 		logger.WithError(err).Errorf("failed to list configs by device")

--- a/pkg/deviced/service/list_devices.go
+++ b/pkg/deviced/service/list_devices.go
@@ -20,6 +20,8 @@ func (self *MetathingsDevicedService) ListDevices(ctx context.Context, req *pb.L
 	dev := req.GetDevice()
 	dev_s := &storage.Device{}
 
+	logger := self.get_logger()
+
 	id := dev.GetId()
 	if id != nil {
 		dev_s.Id = &id.Value
@@ -48,7 +50,7 @@ func (self *MetathingsDevicedService) ListDevices(ctx context.Context, req *pb.L
 	}
 
 	if devs_s, err = self.storage.ListDevices(ctx, dev_s); err != nil {
-		self.logger.WithError(err).Errorf("failed to list devices in storage")
+		logger.WithError(err).Errorf("failed to list devices in storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -56,7 +58,7 @@ func (self *MetathingsDevicedService) ListDevices(ctx context.Context, req *pb.L
 		Devices: copy_devices(devs_s),
 	}
 
-	self.logger.Debugf("list devices")
+	logger.Debugf("list devices")
 
 	return res, nil
 }

--- a/pkg/deviced/service/list_firmware_hubs.go
+++ b/pkg/deviced/service/list_firmware_hubs.go
@@ -17,7 +17,7 @@ func (self *MetathingsDevicedService) ListFirmwareHubs(ctx context.Context, req 
 
 	frm_hub_s := &storage.FirmwareHub{}
 	frm_hub := req.GetFirmwareHub()
-	logger := self.logger
+	logger := self.get_logger()
 
 	if id := frm_hub.GetId(); id != nil {
 		frm_hub_s.Id = &id.Value

--- a/pkg/deviced/service/list_flow_sets.go
+++ b/pkg/deviced/service/list_flow_sets.go
@@ -32,8 +32,10 @@ func (self *MetathingsDevicedService) ListFlowSets(ctx context.Context, req *pb.
 		flwst_s.Alias = &alias.Value
 	}
 
+	logger := self.get_logger()
+
 	if flwsts_s, err = self.storage.ListFlowSets(ctx, flwst_s); err != nil {
-		self.logger.WithError(err).Errorf("failed to list flow set in storage")
+		logger.WithError(err).Errorf("failed to list flow set in storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -41,7 +43,7 @@ func (self *MetathingsDevicedService) ListFlowSets(ctx context.Context, req *pb.
 		FlowSets: copy_flow_sets(flwsts_s),
 	}
 
-	self.logger.Debugf("list flow sets")
+	logger.Debugf("list flow sets")
 
 	return res, nil
 }

--- a/pkg/deviced/service/patch_config.go
+++ b/pkg/deviced/service/patch_config.go
@@ -37,7 +37,7 @@ func (self *MetathingsDevicedService) PatchConfig(ctx context.Context, req *pb.P
 
 	cfg := req.GetConfig()
 	cfg_id_str := cfg.GetId().GetValue()
-	logger := self.logger.WithField("config", cfg_id_str)
+	logger := self.get_logger().WithField("config", cfg_id_str)
 
 	if alias := cfg.GetAlias(); alias != nil {
 		cfg_s.Alias = &alias.Value

--- a/pkg/deviced/service/patch_device.go
+++ b/pkg/deviced/service/patch_device.go
@@ -36,6 +36,8 @@ func (self *MetathingsDevicedService) PatchDevice(ctx context.Context, req *pb.P
 	dev := req.GetDevice()
 	dev_id_str := dev.GetId().GetValue()
 
+	logger := self.get_logger().WithField("device", dev_id_str)
+
 	if alias := dev.GetAlias(); alias != nil {
 		dev_s.Alias = &alias.Value
 	}
@@ -45,7 +47,7 @@ func (self *MetathingsDevicedService) PatchDevice(ctx context.Context, req *pb.P
 	}
 
 	if dev_s, err = self.storage.PatchDevice(ctx, dev_id_str, dev_s); err != nil {
-		self.logger.WithError(err).Errorf("failed to patch device in storage")
+		logger.WithError(err).Errorf("failed to patch device in storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -53,7 +55,7 @@ func (self *MetathingsDevicedService) PatchDevice(ctx context.Context, req *pb.P
 		Device: copy_device(dev_s),
 	}
 
-	self.logger.WithField("id", dev_id_str).Infof("patch device")
+	logger.Infof("patch device")
 
 	return res, nil
 }

--- a/pkg/deviced/service/patch_firmware_hub.go
+++ b/pkg/deviced/service/patch_firmware_hub.go
@@ -31,7 +31,7 @@ func (self *MetathingsDevicedService) PatchFirmwareHub(ctx context.Context, req 
 
 	frm_hub := req.GetFirmwareHub()
 	frm_hub_id_str := frm_hub.GetId().GetValue()
-	logger := self.logger.WithField("firmware_hub", frm_hub_id_str)
+	logger := self.get_logger().WithField("firmware_hub", frm_hub_id_str)
 
 	if alias := frm_hub.GetAlias(); alias != nil {
 		frm_hub_s.Alias = &alias.Value

--- a/pkg/deviced/service/patch_flow_set.go
+++ b/pkg/deviced/service/patch_flow_set.go
@@ -35,13 +35,15 @@ func (self *MetathingsDevicedService) PatchFlowSet(ctx context.Context, req *pb.
 	flwst := req.GetFlowSet()
 	flwst_id_str := flwst.GetId().GetValue()
 
+	logger := self.get_logger().WithField("flow_set", flwst_id_str)
+
 	alias := flwst.GetAlias()
 	if alias != nil {
 		flwst_s.Alias = &alias.Value
 	}
 
 	if flwst_s, err = self.storage.PatchFlowSet(ctx, flwst_id_str, flwst_s); err != nil {
-		self.logger.WithError(err).Errorf("failed to patch flow set in storage")
+		logger.WithError(err).Errorf("failed to patch flow set in storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -49,7 +51,7 @@ func (self *MetathingsDevicedService) PatchFlowSet(ctx context.Context, req *pb.
 		FlowSet: copy_flow_set(flwst_s),
 	}
 
-	self.logger.WithField("flowset", flwst_id_str).Infof("patch flow set")
+	logger.Infof("patch flow set")
 
 	return res, nil
 }

--- a/pkg/deviced/service/pull_frame_from_flow.go
+++ b/pkg/deviced/service/pull_frame_from_flow.go
@@ -17,7 +17,7 @@ func (self *MetathingsDevicedService) PullFrameFromFlow(req *pb.PullFrameFromFlo
 	dev_id := dev_r.GetId().GetValue()
 	cfg_ack := cfg.GetConfigAck().GetValue()
 
-	logger := self.logger.WithFields(log.Fields{
+	logger := self.get_logger().WithFields(log.Fields{
 		"device":  dev_id,
 		"#method": "PullFrameFromFlow",
 	})

--- a/pkg/deviced/service/pull_frame_from_flow_set.go
+++ b/pkg/deviced/service/pull_frame_from_flow_set.go
@@ -18,7 +18,7 @@ func (self *MetathingsDevicedService) PullFrameFromFlowSet(req *pb.PullFrameFrom
 	cfg_flwst_id := cfg_flwst.GetId().GetValue()
 	cfg_ack := cfg.GetConfigAck().GetValue()
 
-	logger := self.logger.WithFields(log.Fields{
+	logger := self.get_logger().WithFields(log.Fields{
 		"config": cfg_req_id,
 	})
 

--- a/pkg/deviced/service/push_frame_to_flow.go
+++ b/pkg/deviced/service/push_frame_to_flow.go
@@ -14,13 +14,15 @@ import (
 
 // TODO(Peer): merge PushFrameToFlow and PushFrameToFlowOnce to one function
 func (self *MetathingsDevicedService) PushFrameToFlow(stm pb.DevicedService_PushFrameToFlowServer) error {
+
+	logger := self.get_logger().WithField("#method", "PushFrameToFlow")
+
 	req, err := stm.Recv()
 	if err != nil {
-		self.logger.WithError(err).Errorf("failed to receive config request")
+		logger.WithError(err).Errorf("failed to receive config request")
 		return status.Errorf(codes.Internal, err.Error())
 	}
 
-	var logger log.FieldLogger
 	var dev_r *pb.OpDevice
 	var dev_id string
 	var cfg_ack, push_ack bool
@@ -36,7 +38,7 @@ func (self *MetathingsDevicedService) PushFrameToFlow(stm pb.DevicedService_Push
 	push_ack = cfg.GetPushAck().GetValue()
 	ctx := stm.Context()
 
-	logger = self.logger.WithFields(log.Fields{
+	logger = logger.WithFields(log.Fields{
 		"config": req_id,
 		"device": dev_id,
 	})

--- a/pkg/deviced/service/push_frame_to_flow_once.go
+++ b/pkg/deviced/service/push_frame_to_flow_once.go
@@ -43,7 +43,7 @@ func (self *MetathingsDevicedService) PushFrameToFlowOnce(ctx context.Context, r
 		req_id = id_helper.NewId()
 	}
 
-	logger := self.logger.WithFields(logrus.Fields{
+	logger := self.get_logger().WithFields(logrus.Fields{
 		"request_id": req_id,
 		"device":     dev_id_str,
 	})

--- a/pkg/deviced/service/put_object.go
+++ b/pkg/deviced/service/put_object.go
@@ -39,16 +39,20 @@ func (self *MetathingsDevicedService) PutObject(ctx context.Context, req *pb.Put
 	reader := bytes.NewReader(content)
 	obj_s := parse_object(obj)
 
+	logger := self.get_logger()
+
 	err := self.simple_storage.PutObject(obj_s, reader)
 	if err != nil {
-		self.logger.WithError(err).Errorf("failed to put object to simple storage")
+		logger.WithError(err).Errorf("failed to put object to simple storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
-	self.logger.WithFields(log.Fields{
+	logger = logger.WithFields(log.Fields{
 		"device": obj_s.Device,
 		"object": obj_s.FullName(),
-	}).Debugf("put object")
+	})
+
+	logger.Debugf("put object")
 
 	return &empty.Empty{}, nil
 }

--- a/pkg/deviced/service/query_frames_from_flow.go
+++ b/pkg/deviced/service/query_frames_from_flow.go
@@ -10,6 +10,7 @@ import (
 	pb_helper "github.com/nayotta/metathings/pkg/common/protobuf"
 	flow "github.com/nayotta/metathings/pkg/deviced/flow"
 	pb "github.com/nayotta/metathings/pkg/proto/deviced"
+	log "github.com/sirupsen/logrus"
 )
 
 func (self *MetathingsDevicedService) QueryFramesFromFlow(ctx context.Context, req *pb.QueryFramesFromFlowRequest) (*pb.QueryFramesFromFlowResponse, error) {
@@ -28,9 +29,13 @@ func (self *MetathingsDevicedService) QueryFramesFromFlow(ctx context.Context, r
 		end_at_r = pb_helper.ToTime(*req.GetTo())
 	}
 
+	logger := self.get_logger().WithFields(log.Fields{
+		"device": dev_id,
+	})
+
 	dev_s, err := self.storage.GetDevice(ctx, dev_id)
 	if err != nil {
-		self.logger.WithError(err).Errorf("failed to get device")
+		logger.WithError(err).Errorf("failed to get device")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -44,7 +49,7 @@ func (self *MetathingsDevicedService) QueryFramesFromFlow(ctx context.Context, r
 
 			f, err := self.new_flow(dev_id, *flw_s.Id)
 			if err != nil {
-				self.logger.WithError(err).Errorf("failed to new flow")
+				logger.WithError(err).Errorf("failed to new flow")
 				return nil, status.Errorf(codes.Internal, err.Error())
 			}
 			defer f.Close()
@@ -55,7 +60,7 @@ func (self *MetathingsDevicedService) QueryFramesFromFlow(ctx context.Context, r
 			})
 
 			if err != nil {
-				self.logger.WithError(err).Errorf("failed to query frame")
+				logger.WithError(err).Errorf("failed to query frame")
 				return nil, status.Errorf(codes.Internal, err.Error())
 			}
 
@@ -69,7 +74,7 @@ func (self *MetathingsDevicedService) QueryFramesFromFlow(ctx context.Context, r
 		}
 	}
 
-	self.logger.Debugf("query frame from flow")
+	logger.Debugf("query frame from flow")
 
 	return res, nil
 }

--- a/pkg/deviced/service/remove_configs_from_device.go
+++ b/pkg/deviced/service/remove_configs_from_device.go
@@ -22,7 +22,7 @@ func (self *MetathingsDevicedService) RemoveConfigsFromDevice(ctx context.Contex
 
 	cfgs := req.GetConfigs()
 
-	logger := self.logger.WithField("device", dev_id_str)
+	logger := self.get_logger().WithField("device", dev_id_str)
 
 	var cfg_ids_str []string
 	for _, cfg := range cfgs {

--- a/pkg/deviced/service/remove_devices_from_firmware_hub.go
+++ b/pkg/deviced/service/remove_devices_from_firmware_hub.go
@@ -35,7 +35,7 @@ func (self *MetathingsDevicedService) RemoveDevicesFromFirmwareHub(ctx context.C
 
 	devs := req.GetDevices()
 
-	logger := self.logger.WithFields(log.Fields{
+	logger := self.get_logger().WithFields(log.Fields{
 		"firmware_hub": fh_id_str,
 	})
 

--- a/pkg/deviced/service/remove_firmware_descriptor_from_firmware_hub.go
+++ b/pkg/deviced/service/remove_firmware_descriptor_from_firmware_hub.go
@@ -40,7 +40,7 @@ func (self *MetathingsDevicedService) RemoveFirmwareDescriptorFromFirmwareHub(ct
 	desc := req.GetFirmwareDescriptor()
 	desc_id_str := desc.GetId().GetValue()
 
-	logger := self.logger.WithFields(log.Fields{
+	logger := self.get_logger().WithFields(log.Fields{
 		"firmware_hub":        fh_id_str,
 		"firmware_descriptor": desc_id_str,
 	})

--- a/pkg/deviced/service/remove_flows_from_flow_set.go
+++ b/pkg/deviced/service/remove_flows_from_flow_set.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -21,26 +20,25 @@ func (self *MetathingsDevicedService) RemoveFlowsFromFlowSet(ctx context.Context
 	flwst := req.GetFlowSet()
 	flwst_id := flwst.GetId().GetValue()
 
+	logger := self.get_logger().WithField("flow_set", flwst_id)
+
 	devs := req.GetDevices()
 	flw_ids, err := self.get_flow_ids_by_devices(ctx, devs)
 	if err != nil {
-		self.logger.WithError(err).Errorf("failed to get flow ids by devices")
+		logger.WithError(err).Errorf("failed to get flow ids by devices")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
 	for _, flw_id := range flw_ids {
 		if err = self.storage.RemoveFlowFromFlowSet(ctx, flwst_id, flw_id); err != nil {
-			self.logger.WithError(err).Errorf("failed to remove flow from flow set")
+			logger.WithError(err).Errorf("failed to remove flow from flow set")
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
 	}
 
 	// TODO(Peer): dynamic remove flow from pulling flow set.
 
-	self.logger.WithFields(log.Fields{
-		"flow_set": flwst_id,
-		"flows":    flw_ids,
-	}).Infof("remove flows from flow set")
+	logger.Infof("remove flows from flow set")
 
 	return &empty.Empty{}, nil
 }

--- a/pkg/deviced/service/remove_object.go
+++ b/pkg/deviced/service/remove_object.go
@@ -36,16 +36,20 @@ func (self *MetathingsDevicedService) RemoveObject(ctx context.Context, req *pb.
 	obj := req.GetObject()
 	obj_s := parse_object(obj)
 
+	logger := self.get_logger()
+
 	err := self.simple_storage.RemoveObject(obj_s)
 	if err != nil {
-		self.logger.WithError(err).Errorf("failed to remove object from simple storage")
+		logger.WithError(err).Errorf("failed to remove object from simple storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
-	self.logger.WithFields(log.Fields{
+	logger = logger.WithFields(log.Fields{
 		"device": obj_s.Device,
 		"object": obj_s.FullName(),
-	}).Infof("remove object")
+	})
+
+	logger.Infof("remove object")
 
 	return &empty.Empty{}, nil
 }

--- a/pkg/deviced/service/rename_object.go
+++ b/pkg/deviced/service/rename_object.go
@@ -50,16 +50,19 @@ func (self *MetathingsDevicedService) RenameObject(ctx context.Context, req *pb.
 	src_s := parse_object(src)
 	dst_s := parse_object(dst)
 
-	err := self.simple_storage.RenameObject(src_s, dst_s)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, err.Error())
-	}
-
-	self.logger.WithFields(log.Fields{
+	logger := self.get_logger().WithFields(log.Fields{
 		"device":      src_s.Device,
 		"source":      src_s.FullName(),
 		"destination": dst_s.FullName(),
-	}).Infof("renmae object")
+	})
+
+	err := self.simple_storage.RenameObject(src_s, dst_s)
+	if err != nil {
+		logger.WithError(err).Errorf("failed to remove object in simple storage")
+		return nil, status.Errorf(codes.Internal, err.Error())
+	}
+
+	logger.Infof("renmae object")
 
 	return &empty.Empty{}, nil
 }

--- a/pkg/deviced/service/service.go
+++ b/pkg/deviced/service/service.go
@@ -66,6 +66,10 @@ type MetathingsDevicedService struct {
 	data_launcher   evaluatord_sdk.DataLauncher
 }
 
+func (self *MetathingsDevicedService) get_logger() log.FieldLogger {
+	return self.logger.WithField("#compnent", "service")
+}
+
 func (self *MetathingsDevicedService) get_device_id_from_context(ctx context.Context) string {
 	var tkn *identityd_pb.Token
 
@@ -148,11 +152,14 @@ func (self *MetathingsDevicedService) get_flow_ids_by_devices(ctx context.Contex
 
 func (self *MetathingsDevicedService) offline_device(ctx context.Context, dev_id string) (err error) {
 	var dev_s *storage.Device
+
+	logger := self.get_logger().WithField("device", dev_id)
+
 	defer func() {
 		if err != nil {
-			self.logger.WithField("device", dev_id).WithError(err).Debugf("failed to offline device")
+			logger.WithError(err).Debugf("failed to offline device")
 		} else {
-			self.logger.WithField("device", dev_id).Debugf("device offline")
+			logger.Debugf("device offline")
 		}
 
 	}()

--- a/pkg/deviced/service/set_device_firmware_descriptor.go
+++ b/pkg/deviced/service/set_device_firmware_descriptor.go
@@ -36,7 +36,7 @@ func (self *MetathingsDevicedService) SetDeviceFirmwareDescriptor(ctx context.Co
 
 	dev_id_str := req.GetDevice().GetId().GetValue()
 	desc_id_str := req.GetFirmwareDescriptor().GetId().GetValue()
-	logger := self.logger.WithFields(log.Fields{
+	logger := self.get_logger().WithFields(log.Fields{
 		"device":              dev_id_str,
 		"firmware_descriptor": desc_id_str,
 	})

--- a/pkg/deviced/service/show_device.go
+++ b/pkg/deviced/service/show_device.go
@@ -15,16 +15,20 @@ func (self *MetathingsDevicedService) ShowDevice(ctx context.Context, _ *empty.E
 	var dev_s *storage.Device
 	var err error
 
+	logger := self.get_logger()
+
 	if dev_s, err = self.get_device_by_context(ctx); err != nil {
-		self.logger.WithError(err).Errorf("failed to get device by context in storage")
+		logger.WithError(err).Errorf("failed to get device by context in storage")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
+
+	logger = logger.WithField("device", *dev_s.Id)
 
 	res := &pb.ShowDeviceResponse{
 		Device: copy_device(dev_s),
 	}
 
-	self.logger.WithField("id", *dev_s.Id).Debugf("show device")
+	logger.Debugf("show device")
 
 	return res, nil
 }

--- a/pkg/deviced/service/show_device_firmware_descriptor.go
+++ b/pkg/deviced/service/show_device_firmware_descriptor.go
@@ -10,7 +10,7 @@ import (
 
 func (self *MetathingsDevicedService) ShowDeviceFirmwareDescriptor(ctx context.Context, _ *empty.Empty) (*pb.ShowDeviceFirmwareDescriptorResponse, error) {
 	dev_id_str := self.get_device_id_from_context(ctx)
-	logger := self.logger.WithField("device", dev_id_str)
+	logger := self.get_logger().WithField("device", dev_id_str)
 
 	fd_s, err := self.get_device_firmware_descriptor(ctx, dev_id_str)
 	if err != nil {

--- a/pkg/deviced/service/stream_call.go
+++ b/pkg/deviced/service/stream_call.go
@@ -14,7 +14,7 @@ func (self *MetathingsDevicedService) StreamCall(stm pb.DevicedService_StreamCal
 	var dev_s *storage.Device
 	var err error
 
-	logger := self.logger
+	logger := self.get_logger()
 
 	if req, err = stm.Recv(); err != nil {
 		logger.WithError(err).Errorf("failed to recv config msg")
@@ -25,7 +25,7 @@ func (self *MetathingsDevicedService) StreamCall(stm pb.DevicedService_StreamCal
 	dev_id_str := req.GetDevice().GetId().GetValue()
 	mdl_name_str := cfg.GetName().GetValue()
 	meth_str := cfg.GetMethod().GetValue()
-	logger = self.logger.WithFields(log.Fields{
+	logger = self.get_logger().WithFields(log.Fields{
 		"device": dev_id_str,
 		"module": mdl_name_str,
 		"method": meth_str,

--- a/pkg/deviced/service/sync_device_firmware_descriptor.go
+++ b/pkg/deviced/service/sync_device_firmware_descriptor.go
@@ -32,7 +32,7 @@ func (self *MetathingsDevicedService) SyncDeviceFirmwareDescriptor(ctx context.C
 	var err error
 
 	dev_id_str := req.GetDevice().GetId().GetValue()
-	logger := self.logger.WithField("device", dev_id_str)
+	logger := self.get_logger().WithField("device", dev_id_str)
 
 	if dev_s, err = self.storage.GetDevice(ctx, dev_id_str); err != nil {
 		logger.WithError(err).Errorf("failed to get devicein storage")

--- a/pkg/deviced/service/unary_call.go
+++ b/pkg/deviced/service/unary_call.go
@@ -36,7 +36,7 @@ func (self *MetathingsDevicedService) UnaryCall(ctx context.Context, req *pb.Una
 
 	dev_id_str := req.GetDevice().GetId().GetValue()
 
-	logger := self.logger.WithFields(log.Fields{
+	logger := self.get_logger().WithFields(log.Fields{
 		"device": dev_id_str,
 	})
 	if dev_s, err = self.storage.GetDevice(ctx, dev_id_str); err != nil {

--- a/pkg/deviced/storage/helper.go
+++ b/pkg/deviced/storage/helper.go
@@ -10,3 +10,19 @@ func parse_error(err error) error {
 		return err
 	}
 }
+
+func wrap_module(mdl *Module) *Module {
+	if mdl.DeviceId != nil {
+		mdl.Device = &Device{Id: mdl.DeviceId}
+	}
+
+	return mdl
+}
+
+func wrap_flow(flw *Flow) *Flow {
+	if flw.DeviceId != nil {
+		flw.Device = &Device{Id: flw.DeviceId}
+	}
+
+	return flw
+}

--- a/pkg/deviced/storage/storage_with_tracer.go
+++ b/pkg/deviced/storage/storage_with_tracer.go
@@ -24,29 +24,47 @@ func (s *TracedStorage) DeleteDevice(ctx context.Context, id string) error {
 
 	return s.Storage.DeleteDevice(ctx, id)
 }
+
 func (s *TracedStorage) PatchDevice(ctx context.Context, id string, device *Device) (*Device, error) {
-	span, ctx := s.TraceWrapper(ctx, "patchDevice")
+	span, ctx := s.TraceWrapper(ctx, "PatchDevice")
 	defer span.Finish()
 
 	return s.Storage.PatchDevice(ctx, id, device)
 }
-func (s *TracedStorage) GetDevice(ctx context.Context, id string) (*Device, error) {
+
+func (s *TracedStorage) ModifyDevice(ctx context.Context, id string, device *Device) error {
+	span, ctx := s.TraceWrapper(ctx, "ModifyDevice")
+	defer span.Finish()
+
+	return s.Storage.ModifyDevice(ctx, id, device)
+}
+
+func (s *TracedStorage) GetDevice(ctx context.Context, id string, opts ...GetDeviceOption) (*Device, error) {
 	span, ctx := s.TraceWrapper(ctx, "GetDevice")
 	defer span.Finish()
 
-	return s.Storage.GetDevice(ctx, id)
+	return s.Storage.GetDevice(ctx, id, opts...)
 }
+
 func (s *TracedStorage) ListDevices(ctx context.Context, dev *Device) ([]*Device, error) {
 	span, ctx := s.TraceWrapper(ctx, "ListDevices")
 	defer span.Finish()
 
 	return s.Storage.ListDevices(ctx, dev)
 }
+
 func (s *TracedStorage) GetDeviceByModuleId(ctx context.Context, id string) (*Device, error) {
 	span, ctx := s.TraceWrapper(ctx, "GetDeviceByModuleId")
 	defer span.Finish()
 
 	return s.Storage.GetDeviceByModuleId(ctx, id)
+}
+
+func (s *TracedStorage) ListModulesByDeviceId(ctx context.Context, dev_id string, opts ...ListModulesByDeviceIdOption) ([]*Module, error) {
+	span, ctx := s.TraceWrapper(ctx, "ListModulesByDeviceId")
+	defer span.Finish()
+
+	return s.Storage.ListModulesByDeviceId(ctx, dev_id, opts...)
 }
 
 func (s *TracedStorage) CreateModule(ctx context.Context, dev *Module) (*Module, error) {
@@ -61,18 +79,28 @@ func (s *TracedStorage) DeleteModule(ctx context.Context, id string) error {
 
 	return s.Storage.DeleteModule(ctx, id)
 }
+
 func (s *TracedStorage) PatchModule(ctx context.Context, id string, module *Module) (*Module, error) {
 	span, ctx := s.TraceWrapper(ctx, "PatchModule")
 	defer span.Finish()
 
 	return s.Storage.PatchModule(ctx, id, module)
 }
+
+func (s *TracedStorage) ModifyModule(ctx context.Context, id string, module *Module) error {
+	span, ctx := s.TraceWrapper(ctx, "ModifyModule")
+	defer span.Finish()
+
+	return s.Storage.ModifyModule(ctx, id, module)
+}
+
 func (s *TracedStorage) GetModule(ctx context.Context, id string) (*Module, error) {
 	span, ctx := s.TraceWrapper(ctx, "GetModule")
 	defer span.Finish()
 
 	return s.Storage.GetModule(ctx, id)
 }
+
 func (s *TracedStorage) ListModules(ctx context.Context, mdl *Module) ([]*Module, error) {
 	span, ctx := s.TraceWrapper(ctx, "ListModules")
 	defer span.Finish()

--- a/pkg/identityd2/service/validate_token.go
+++ b/pkg/identityd2/service/validate_token.go
@@ -25,7 +25,7 @@ func (self *MetathingsIdentitydService) validate_token(ctx context.Context, tkn 
 	}
 
 	tkn_txt_str := tkn_txt.GetValue()
-	if tkn_s, err = self.storage.GetTokenByText(ctx, tkn_txt_str); err != nil {
+	if tkn_s, err = self.storage.GetViewTokenByText(ctx, tkn_txt_str); err != nil {
 		self.logger.WithError(err).Errorf("failed to get token by text in storage")
 		return nil, status.Errorf(codes.Unauthenticated, policy.ErrUnauthenticated.Error())
 	}

--- a/pkg/identityd2/storage/helper.go
+++ b/pkg/identityd2/storage/helper.go
@@ -1,0 +1,11 @@
+package metathings_identityd2_storage
+
+func wrap_token(tkn *Token) *Token {
+	tkn.Domain = &Domain{Id: tkn.DomainId}
+	tkn.Entity = &Entity{Id: tkn.EntityId}
+	if tkn.CredentialId != nil {
+		tkn.Credential = &Credential{Id: tkn.CredentialId}
+	}
+
+	return tkn
+}

--- a/pkg/identityd2/storage/storage.go
+++ b/pkg/identityd2/storage/storage.go
@@ -240,6 +240,7 @@ type Storage interface {
 	DeleteToken(ctx context.Context, id string) error
 	RefreshToken(ctx context.Context, id string, expires_at time.Time) error
 	GetTokenByText(ctx context.Context, text string) (*Token, error)
+	GetViewTokenByText(ctx context.Context, text string) (*Token, error)
 	GetToken(ctx context.Context, id string) (*Token, error)
 	ListTokens(context.Context, *Token) ([]*Token, error)
 }

--- a/pkg/identityd2/storage/storage_with_tracer.go
+++ b/pkg/identityd2/storage/storage_with_tracer.go
@@ -404,6 +404,13 @@ func (s *TracedStorage) GetTokenByText(ctx context.Context, text string) (*Token
 	return s.StorageImpl.GetTokenByText(ctx, text)
 }
 
+func (s *TracedStorage) GetViewTokenByText(ctx context.Context, text string) (*Token, error) {
+	span, ctx := s.TraceWrapper(ctx, "GetViewTokenByText")
+	defer span.Finish()
+
+	return s.StorageImpl.GetViewTokenByText(ctx, text)
+}
+
 func (s *TracedStorage) GetToken(ctx context.Context, id string) (*Token, error) {
 	span, ctx := s.TraceWrapper(ctx, "GetToken")
 	defer span.Finish()


### PR DESCRIPTION
:zap: improve `Heartbeat`, `ValidateToken` and `CheckToken` interfaces query too slow problems.